### PR TITLE
Increase blocking timeout value

### DIFF
--- a/support/standalone.xml
+++ b/support/standalone.xml
@@ -32,6 +32,7 @@
       <property name="org.uberfire.nio.git.dir" value="${jboss.home.dir}/bin"/>
       <property name="org.uberfire.metadata.index.dir" value="${jboss.home.dir}/bin"/>
       <property name="org.guvnor.m2repo.dir" value="${jboss.home.dir}/bin"/>
+      <property name="jboss.as.management.blocking.timeout" value="900"/>
 			<!--  <property name="kie.maven.settings.custom" value="${jboss.home.dir}/bin/.settings.xml"/> -->
    </system-properties>
    <management>


### PR DESCRIPTION
The default value for `jboss.as.management.blocking.timeout` is 300 (five minutes), which is not sufficient on some systems (the VM I am using, for example takes 675 seconds to start up).
This PR updates the timeout to 900 seconds.