### PR TITLE
Bz1287604 fix

### DIFF
--- a/projects/brms-coolstore-demo/pom.xml
+++ b/projects/brms-coolstore-demo/pom.xml
@@ -310,7 +310,7 @@
 
 		<!-- Define the version of JBoss BRMS product to import. -->
 		<!-- jboss.brms.version>6.0.3-redhat-4</jboss.brms.version -->
-	<jboss.brms.version>6.1.0.GA-redhat-2</jboss.brms.version> 
+		<jboss.brms.version>6.2.0.GA-redhat-1</jboss.brms.version>
 	</properties>
 
 	<repositories>
@@ -460,7 +460,13 @@
 			<groupId>org.jbpm</groupId>
 			<artifactId>jbpm-bpmn2</artifactId>
 		</dependency>
-		
+
+		<!-- Required in BxMS >= 6.2 when using Guided Decision tables -->
+		<dependency>
+			<groupId>org.drools</groupId>
+			<artifactId>drools-workbench-models-guided-dtable</artifactId>
+		</dependency>
+
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/support/standalone.xml
+++ b/support/standalone.xml
@@ -33,6 +33,7 @@
 			<property name="org.kie.server.repo" value="${jboss.server.data.dir}"/>
       <property name="org.uberfire.metadata.index.dir" value="${jboss.home.dir}/bin"/>
 			<property name="org.guvnor.m2repo.dir" value="${jboss.home.dir}/bin"/>
+      <property name="kie.maven.settings.custom" value="${jboss.home.dir}/bin/.settings.xml"/>
    </system-properties>
    <management>
       <security-realms>


### PR DESCRIPTION
I managed to make the demo work as expected, I had to:

 1. update the BxMS version: <jboss.brms.version>6.2.0.GA-redhat-1</jboss.brms.version>

 2. since the demo app is using a kjar which includes Guided Decision Tables, the demo app must include the following dependency (new in BxMS 6.2!):

```
  <dependency>
    <groupId>org.drools</groupId>
    <artifactId>drools-workbench-models-guided-dtable</artifactId>
  </dependency>
```

 3. add missing (previously removed) kie.maven.settings.custom property to standalone.xml.
